### PR TITLE
Removed unique() from Department generator call

### DIFF
--- a/src/Faker/Provider/Commerce.php
+++ b/src/Faker/Provider/Commerce.php
@@ -35,7 +35,7 @@ class Commerce extends Base
         }
 
         for ($i = 0; $i < $max; $i++) {
-            $categories[] = $this->generator->unique()->category;
+            $categories[] = $this->generator->category;
         }
 
         if (count($categories) >= 2) {


### PR DESCRIPTION
The unique() call in the department method creates a "Maximum retries of 10000 reached without finding a unique value" error.