### PR TITLE
add `category` to readme at `Commerce` section

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ $faker->promotionCode; // KillerPromotion257835
 $faker->department; // Kids & Games
 $faker->department(6); // Games, Industrial, Books & Automotive
 $faker->department(3, true); // Jewelry, Music & Shoes
+$faker->category; // Computers
 $faker->productName; // Small Rubber Bottle
 
 ```


### PR DESCRIPTION
I have to read the code to make sure that this package was provide `product category`, and it was. But, it wasn't mentioned in the readme